### PR TITLE
favicons and styling improvements

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -21,6 +21,9 @@
 	
 
 	<script type="template" id="template-item">
+		<div class="favicon">
+			<img src="<%= favIconUrl %>"></img>
+		</div>
 		<div class="item-first-row" title="<%= title.replace(/\"/g, '\"') %>" data-closed="<%= isClosed %>"><%= title %></div>
 		<div class="item-second-row" title="<%= url %>"><%= url %></div>
 	</script>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -101,6 +101,7 @@ $(function() {
 		defaults: {
 			title: '<no title>',
 			url: '<no url>',
+			favIconUrl: '',
 			id: -1,
 			actTime: 0,
 			isClosed: false,
@@ -286,7 +287,6 @@ $(function() {
 			}, this);
 
 			var v = e.currentTarget.value;
-
 			
 
 			/**
@@ -350,13 +350,20 @@ $(function() {
 
 	chrome.runtime.onMessage.addListener(function (request, sender, sendBack){
 		if (request.action == 'get-tabs-response') {
-			items.reset(request.value);
+			var tabs = request.value;
+			chrome.tabs.query({}, function(moreTabInfo){
+				tabs.forEach(function(tab) {
+					// include favIconUrl (and other less important properties)
+					_.extend(tab, _.findWhere(moreTabInfo, {id: tab.id}));
+				});
 
-			if (items.length) {
-				items.at(0).set('selected', 1);
-			}
+				items.reset(tabs);
+
+				if (items.length) {
+					items.at(0).set('selected', 1);
+				}
+			});
 		}
 	});
-
 
 });

--- a/styles/style.css
+++ b/styles/style.css
@@ -51,6 +51,21 @@ body {
 	background: rgb(87, 87, 87);;
 }
 
+.favicon {
+	float: left;
+	width: 32px;
+	height: 32px;
+	line-height: 32px;
+	margin-right: 10px;
+	text-align: center;
+}
+
+.favicon img {
+	max-width: 28px;
+	max-height: 28px;
+	vertical-align: middle;
+}
+
 .item-first-row {
 	font-size: 15px;
 	white-space: nowrap;

--- a/styles/style.css
+++ b/styles/style.css
@@ -9,15 +9,17 @@ body {
 	max-width: 400px;
 	padding: 5px;
 	background: rgb(64,64,64);
+	font-family: Arial, sans-serif;
 }
 
 #search {
 	width: 100%;
 	padding: 2px 5px;
 	font-size: 16px;
-	font-family: Arial;
+	font-weight: bold;
 	display: block;
 	margin: 0;
+	background: rgb(230,230,230);
 }
 
 
@@ -62,7 +64,7 @@ body {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	color: rgb(196,255,225);
+	color: rgb(255,255,255);
 }
 
 [data-closed=true] {


### PR DESCRIPTION
I added favicons to the list of tabs. Now it looks like this:

![image](https://cloud.githubusercontent.com/assets/2964543/4098107/3293b0b0-2fff-11e4-9388-e0d1e84e3b4e.png)

Additionally I modified fonts and colors slightly to match them more to sublime's default scheme (Monokai).

By the way, it could be a nice feature to enable selection of a color scheme on the options page.
